### PR TITLE
Updated typings for inquirer version 1.0.2

### DIFF
--- a/lib/inquirer.d.ts
+++ b/lib/inquirer.d.ts
@@ -1,3 +1,5 @@
+import { Promise } from 'es6-promise';
+
 export function restoreDefaultPrompts (): void;
 
 /**
@@ -16,7 +18,7 @@ export function createPromptModule (): PromptModule;
  * @param cb Callback being passed the user answers
  * @return
  */
-export function prompt (questions: Questions, cb?: (answers: Answers) => any): UI.Prompt;
+export function prompt (questions: Questions): Promise<Answers>;
 
 export var prompts: Prompts;
 export var Separator: objects.SeparatorStatic;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitAny": true
+  },
+  "files": [
+    "lib/inquirer.d.ts",
+    "typings/main.d.ts"
+  ]
+}

--- a/typings.json
+++ b/typings.json
@@ -1,4 +1,7 @@
 {
   "name": "inquirer",
-  "main": "lib/inquirer.d.ts"
+  "main": "lib/inquirer.d.ts",
+  "dependencies": {
+    "es6-promise": "registry:npm/es6-promise#3.0.0+20160211003958"
+  }
 }


### PR DESCRIPTION
Inquirer no longer uses the callback argument and has switched to Promises. I was unsure where to get the Promise definition from, so I used es6-promise.
