### PR TITLE
Answer can be an array of strings when using a list

### DIFF
--- a/lib/inquirer.d.ts
+++ b/lib/inquirer.d.ts
@@ -102,7 +102,7 @@ export interface Question {
  * A key/value hash containing the client answers in each prompt.
  */
 export interface Answers {
-    [key: string]: string|boolean;
+    [key: string]: string | boolean | string[];
 }
 
 export namespace UI {


### PR DESCRIPTION
When using `inquirer.prompt` with a list, ie.

``` javascript
inquirer.prompt([
{
    type: 'list',
    name: 'size',
    message: 'What size do you need?',
    choices: ['Large', 'Medium', 'Small'],
    filter: function (val) {
       return val.toLowerCase();
    }
}
]);
```

The answer will be an array of strings, the current typing does not allow this.
